### PR TITLE
Online monitor enhance

### DIFF
--- a/pymosa/online_monitor/hit_correlator_converter.py
+++ b/pymosa/online_monitor/hit_correlator_converter.py
@@ -70,7 +70,7 @@ class HitCorrelator(Transceiver):
 
     def setup_interpretation(self):
         self.active_tab = None  # Stores name of active tab in online monitor
-        self.hit_corr_tab = 'HIT_Correlator'  # name of correlator tab, has to match with name specified in configuration.yaml for online monitor
+        self.hit_corr_tab = None  # Name of receiver tab, is being set by sending command 
         self.start_signal = 1  # will be set in handle_command function; correlation starts if this is set to 0
         self.active_dut1 = 0
         self.active_dut2 = 0
@@ -267,3 +267,5 @@ class HitCorrelator(Transceiver):
                 elif self.transpose_checkbox == 2:
                     self.transpose = True
                 create_corr_hist(self.active_dut1, self.active_dut2, self.transpose)
+        elif 'RECEIVER' in command[0]:
+            self.hit_corr_tab = command[0].split()[1]      

--- a/pymosa/online_monitor/hit_correlator_converter.py
+++ b/pymosa/online_monitor/hit_correlator_converter.py
@@ -1,10 +1,6 @@
-import os
-
-import yaml
 import gc
 import numpy as np
 from numba import njit
-from zmq.utils import jsonapi
 
 from online_monitor.converter.transceiver import Transceiver
 from online_monitor.utils import utils
@@ -204,9 +200,6 @@ class HitCorrelator(Transceiver):
             remove_background(self.column_corr_hist, self.row_corr_hist, self.remove_background_percentage)
 
         return [{'column': self.column_corr_hist, 'row': self.row_corr_hist}]
-
-    def serialize_data(self, data):
-        return jsonapi.dumps(data, cls=utils.NumpyEncoder)
 
     def handle_command(self, command):
         # Reset histogramms and data buffer, call garbage collector

--- a/pymosa/online_monitor/hit_correlator_receiver.py
+++ b/pymosa/online_monitor/hit_correlator_receiver.py
@@ -21,6 +21,9 @@ class HitCorrelator(Receiver):
         if not 'duts' in self.config:
             raise KeyError("Define DUTs in the configuration.yaml")
 
+        # Send the receiver name to the converter in order for it to only interpret data when corresponding receiver is active
+        self.send_command(f'RECEIVER {self.name}')    
+
     def setup_widgets(self, parent, name):
         self.occupancy_images_columns = {}
         self.occupancy_images_rows = {}

--- a/pymosa/online_monitor/hit_correlator_receiver.py
+++ b/pymosa/online_monitor/hit_correlator_receiver.py
@@ -14,6 +14,7 @@ from online_monitor.receiver.receiver import Receiver
 class HitCorrelator(Receiver):
 
     def setup_receiver(self):
+        self.occupancy_data = {'column': None, 'row': None} 
         self.set_bidirectional_communication()  # We want to change converter settings
         
         # Check that we have the DUTs defined
@@ -110,10 +111,7 @@ class HitCorrelator(Receiver):
         occupancy_graphics1.show()
         view1 = occupancy_graphics1.addViewBox()
         occupancy_img_col = pg.ImageItem(border='w')
-        poss = np.array([0.0, 0.01, 0.5, 1.0])
-        color = np.array([[1.0, 1.0, 1.0, 1.0], [0.267004, 0.004874, 0.329415, 1.0], [0.127568, 0.566949, 0.550556, 1.0], [0.993248, 0.906157, 0.143936, 1.0]])  # Zero is white
-        mapp = pg.ColorMap(poss, color)
-        lutt = mapp.getLookupTable(0.0, 1.0, 100)
+        lutt = utils.lut_from_colormap("viridis")
         occupancy_img_col.setLookupTable(lutt, update=True)
         self.plot1 = pg.PlotWidget(viewBox=view1)
         self.plot1.getAxis('bottom').setLabel(text='Columns')
@@ -196,12 +194,16 @@ class HitCorrelator(Receiver):
 
     def handle_data(self, data):
         if 'meta_data' not in data:
-            for key in data:
-                if 'column' == key:
-                    self.occupancy_images_columns.setImage(data[key][:, :], autoDownsample=True)
-                    self.plot1.setTitle('Column Correlation, Sum: %i' % data[key][:, :].sum())
-                if 'row' == key:
-                    self.occupancy_images_rows.setImage(data[key][:, :], autoDownsample=True)
-                    self.plot2.setTitle('Row Correlation, Sum: %i' % data[key][:, :].sum())
+            self.occupancy_data.update(data)
         else:
             self.rate_label.setText('Readout Rate: %d Hz' % data['meta_data']['fps'])
+
+    def refresh_data(self):
+        for dim, data in self.occupancy_data.items():
+            if data is not None:
+                if dim == 'column':
+                    self.occupancy_images_columns.setImage(data[:, :], autoDownsample=True)
+                    self.plot1.setTitle('Column Correlation, Sum: %i' % data[:, :].sum())
+                elif dim == 'row':
+                    self.occupancy_images_rows.setImage(data[:, :], autoDownsample=True)
+                    self.plot2.setTitle('Row Correlation, Sum: %i' % data[:, :].sum())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ numba
 numpy
 online_monitor>=0.5.2
 pymosa_mimosa26_interpreter>=1.0.0
-pyqt5
 pyyaml
 tables
 tqdm
-pyqtgraph>=0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bitarray>=0.8.1
 matplotlib
 numba
 numpy
-online_monitor>=0.5.2
+online_monitor>=0.6.0
 pymosa_mimosa26_interpreter>=1.0.0
 pyyaml
 tables


### PR DESCRIPTION
Adapt the `pymosa` online_monitor plugin to `online-monitor==0.6.0` version, separating plotting from data handling, allowing to plot e.g. all 6 Mimosas at the same time without causing stutters/freezes. Additionally, remove hard-coded receiver name in converter, acquire it dynamically instead to allow arbitrary names. Some cleanup 